### PR TITLE
Use options

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -85,9 +85,7 @@ def main(script_path: Optional[str],
              stderr, options)
 
     if options.install_types and not sources:
-        install_types(
-            options.cache_dir, formatter, options, non_interactive=options.non_interactive
-        )
+        install_types(formatter, options, non_interactive=options.non_interactive)
         return
 
     res, messages, blockers = run_build(sources, options, fscache, t0, stdout, stderr)
@@ -96,9 +94,7 @@ def main(script_path: Optional[str],
         missing_pkgs = read_types_packages_to_install(options.cache_dir, after_run=True)
         if missing_pkgs:
             # Install missing type packages and rerun build.
-            install_types(
-                options.cache_dir, formatter, options, after_run=True, non_interactive=True
-            )
+            install_types(formatter, options, after_run=True, non_interactive=True)
             fscache.flush()
             print()
             res, messages, blockers = run_build(sources, options, fscache, t0, stdout, stderr)
@@ -125,8 +121,7 @@ def main(script_path: Optional[str],
         stdout.flush()
 
     if options.install_types and not options.non_interactive:
-        result = install_types(options.cache_dir, formatter, options, after_run=True,
-                               non_interactive=False)
+        result = install_types(formatter, options, after_run=True, non_interactive=False)
         if result:
             print()
             print("note: Run mypy again for up-to-date results with installed types")
@@ -1154,14 +1149,13 @@ def read_types_packages_to_install(cache_dir: str, after_run: bool) -> List[str]
         return [line.strip() for line in f.readlines()]
 
 
-def install_types(cache_dir: str,
-                  formatter: util.FancyFormatter,
+def install_types(formatter: util.FancyFormatter,
                   options: Options,
                   *,
                   after_run: bool = False,
                   non_interactive: bool = False) -> bool:
     """Install stub packages using pip if some missing stubs were detected."""
-    packages = read_types_packages_to_install(cache_dir, after_run)
+    packages = read_types_packages_to_install(options.cache_dir, after_run)
     if not packages:
         # If there are no missing stubs, generate no output.
         return False


### PR DESCRIPTION
This is an alternative implementation for https://github.com/python/mypy/pull/11457 using `options: Options` to pass the python executable and the cache dir to `install_types`